### PR TITLE
Add subfolder into ir_attachment bucket

### DIFF
--- a/ir_attachment_minio/ir_attachment.py
+++ b/ir_attachment_minio/ir_attachment.py
@@ -25,11 +25,11 @@ class IrAttachment(osv.osv):
         ctx = context.copy()
         if 'datas_fname' in vals:
             ctx['datas_minio_filename'] = slugify(
-                vals['datas_fname'], replacements=[['.', '.']]
+                vals['datas_fname'], separator='.'
             )
         elif 'filename' in vals:
             ctx['datas_minio_filename'] = slugify(
-                vals['filename'], replacements=[['.', '.']]
+                vals['filename'], separator='.'
             )
         if 'datas' in vals and vals['datas']:
             minioize(vals)
@@ -45,11 +45,11 @@ class IrAttachment(osv.osv):
             minioize(vals)
         if 'datas_fname' in vals:
             ctx['datas_minio_filename'] = slugify(
-                vals['datas_fname'], replacements=[['.', '.']]
+                vals['datas_fname'], separator='.'
             )
         elif 'filename' in vals:
             ctx['datas_minio_filename'] = slugify(
-                vals['filename'], replacements=[['.', '.']]
+                vals['filename'], separator='.'
             )
         ctx['subfolder'] = ctx.get('default_res_model')
         return super(

--- a/ir_attachment_minio/ir_attachment.py
+++ b/ir_attachment_minio/ir_attachment.py
@@ -26,6 +26,8 @@ class IrAttachment(osv.osv):
             ctx['datas_minio_filename'] = vals['filename']
         if 'datas' in vals and vals['datas']:
             minioize(vals)
+
+        ctx['subfolder'] = ctx.get('default_res_model')
         return super(IrAttachment, self).create(cursor, uid, vals, context=ctx)
 
     def write(self, cursor, uid, ids, vals, context=None):
@@ -36,6 +38,7 @@ class IrAttachment(osv.osv):
             minioize(vals)
         if 'filename' in vals:
             ctx['datas_minio_filename'] = vals['filename']
+        ctx['subfolder'] = ctx.get('default_res_model')
         return super(
             IrAttachment, self).write(cursor, uid, ids, vals, context=ctx
         )

--- a/ir_attachment_minio/ir_attachment.py
+++ b/ir_attachment_minio/ir_attachment.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 from osv import osv
 from minio_backend.fields import S3File
+from slugify import slugify
 
 
 def minioize(vals):
@@ -22,8 +23,14 @@ class IrAttachment(osv.osv):
         if context is None:
             context = {}
         ctx = context.copy()
-        if 'filename' in vals:
-            ctx['datas_minio_filename'] = vals['filename']
+        if 'datas_fname' in vals:
+            ctx['datas_minio_filename'] = slugify(
+                vals['datas_fname'], replacements=[['.', '.']]
+            )
+        elif 'filename' in vals:
+            ctx['datas_minio_filename'] = slugify(
+                vals['filename'], replacements=[['.', '.']]
+            )
         if 'datas' in vals and vals['datas']:
             minioize(vals)
 
@@ -36,8 +43,14 @@ class IrAttachment(osv.osv):
         ctx = context.copy()
         if 'datas' in vals:
             minioize(vals)
-        if 'filename' in vals:
-            ctx['datas_minio_filename'] = vals['filename']
+        if 'datas_fname' in vals:
+            ctx['datas_minio_filename'] = slugify(
+                vals['datas_fname'], replacements=[['.', '.']]
+            )
+        elif 'filename' in vals:
+            ctx['datas_minio_filename'] = slugify(
+                vals['filename'], replacements=[['.', '.']]
+            )
         ctx['subfolder'] = ctx.get('default_res_model')
         return super(
             IrAttachment, self).write(cursor, uid, ids, vals, context=ctx

--- a/ir_attachment_minio/ir_attachment.py
+++ b/ir_attachment_minio/ir_attachment.py
@@ -34,10 +34,6 @@ class IrAttachment(osv.osv):
             ctx['datas_minio_filename'] = slugify(
                 vals['datas_fname'], separator='.'
             )
-        elif 'filename' in vals:
-            ctx['datas_minio_filename'] = slugify(
-                vals['filename'], separator='.'
-            )
         if 'datas' in vals and vals['datas']:
             minioize(vals)
         ctx['subfolder'] = self.get_subfolder(vals, context)
@@ -52,10 +48,6 @@ class IrAttachment(osv.osv):
         if 'datas_fname' in vals:
             ctx['datas_minio_filename'] = slugify(
                 vals['datas_fname'], separator='.'
-            )
-        elif 'filename' in vals:
-            ctx['datas_minio_filename'] = slugify(
-                vals['filename'], separator='.'
             )
         ctx['subfolder'] = self.get_subfolder(vals, context)
         return super(

--- a/ir_attachment_minio/ir_attachment.py
+++ b/ir_attachment_minio/ir_attachment.py
@@ -19,6 +19,13 @@ class IrAttachment(osv.osv):
     _name = 'ir.attachment'
     _inherit = 'ir.attachment'
 
+    def get_subfolder(self, vals, context):
+        subfolder = context.get(
+            'default_res_model',
+            vals.get('res_model', None)
+        )
+        return subfolder
+
     def create(self, cursor, uid, vals, context=None):
         if context is None:
             context = {}
@@ -33,8 +40,7 @@ class IrAttachment(osv.osv):
             )
         if 'datas' in vals and vals['datas']:
             minioize(vals)
-
-        ctx['subfolder'] = ctx.get('default_res_model')
+        ctx['subfolder'] = self.get_subfolder(vals, context)
         return super(IrAttachment, self).create(cursor, uid, vals, context=ctx)
 
     def write(self, cursor, uid, ids, vals, context=None):
@@ -51,7 +57,7 @@ class IrAttachment(osv.osv):
             ctx['datas_minio_filename'] = slugify(
                 vals['filename'], separator='.'
             )
-        ctx['subfolder'] = ctx.get('default_res_model')
+        ctx['subfolder'] = self.get_subfolder(vals, context)
         return super(
             IrAttachment, self).write(cursor, uid, ids, vals, context=ctx
         )

--- a/ir_attachment_minio/requirements.txt
+++ b/ir_attachment_minio/requirements.txt
@@ -1,0 +1,1 @@
+python-slugify<=5.0.0

--- a/ir_attachment_minio/tests/__init__.py
+++ b/ir_attachment_minio/tests/__init__.py
@@ -15,7 +15,7 @@ class TestIrAttachmentMinio(testing.OOTestCaseWithCursor):
 
         attach_id = attach_obj.create(cursor, uid, {
             'name': 'This is a description',
-            'filename': 'test.txt',
+            'datas_fname': 'test.txt',
             'datas': base64.b64encode(content)
         })
 
@@ -37,7 +37,7 @@ class TestIrAttachmentMinio(testing.OOTestCaseWithCursor):
 
         attach_id = attach_obj.create(cursor, uid, {
             'name': 'This is a description',
-            'filename': 'test2.txt',
+            'datas_fname': 'test2.txt',
             'datas': base64.b64encode(content)
         })
 
@@ -65,7 +65,7 @@ class TestIrAttachmentMinio(testing.OOTestCaseWithCursor):
 
         attach_id = attach_obj.create(cursor, uid, {
             'name': 'This is a description',
-            'filename': 'test.txt',
+            'datas_fname': 'test.txt',
             'datas': base64.b64encode(content)
         })
 
@@ -86,7 +86,7 @@ class TestIrAttachmentMinio(testing.OOTestCaseWithCursor):
 
         attach_id = attach_obj.create(cursor, uid, {
             'name': 'This is a description',
-            'filename': 'test.txt',
+            'datas_fname': 'test.txt',
             'datas': base64.b64encode(content)
         })
 

--- a/minio_backend/fields.py
+++ b/minio_backend/fields.py
@@ -14,8 +14,9 @@ class S3File(fields.text):
     _classic_write = False
     pg_type = 'text', 'text'
 
-    def __init__(self, string, bucket, **args):
+    def __init__(self, string, bucket, subfolder='', **args):
         self.bucket = bucket
+        self.subfolder = subfolder
         super(S3File, self).__init__(
             string=string, widget='binary', **args
         )
@@ -29,9 +30,10 @@ class S3File(fields.text):
     def get_filename(self, obj, rid, name, context=None):
         if context is None:
             context = {}
-        if context.get('subfolder'):
+        subfolder = context.get('subfolder', self.subfolder)
+        if subfolder:
             return '{}/{}/{}_{}'.format(
-                obj._table, context['subfolder'], rid, name)
+                obj._table, subfolder, rid, name)
         return '{}/{}_{}'.format(obj._table, rid, name)
 
     def set(self, cursor, obj, rid, name, value, user=None, context=None):

--- a/minio_backend/fields.py
+++ b/minio_backend/fields.py
@@ -26,8 +26,13 @@ class S3File(fields.text):
         res = dict([(x[0], x[1]) for x in cursor.fetchall()])
         return res
 
-    def get_filename(self, obj, rid, name):
-        return '%s/%s_%s' % (obj._table, rid, name)
+    def get_filename(self, obj, rid, name, context=None):
+        if context is None:
+            context = {}
+        if context.get('subfolder'):
+            return '{}/{}/{}_{}'.format(
+                obj._table, context['subfolder'], rid, name)
+        return '{}/{}_{}'.format(obj._table, rid, name)
 
     def set(self, cursor, obj, rid, name, value, user=None, context=None):
         if context is None:
@@ -47,12 +52,15 @@ class S3File(fields.text):
                     if ctx_filename:
                         if oid != ctx_filename:
                             client.remove_object(self.bucket, oid)
-                        filename = self.get_filename(obj, rid, ctx_filename)
+                        filename = self.get_filename(
+                            obj, rid, ctx_filename, context=context)
                 else:
                     if ctx_filename:
-                        filename = self.get_filename(obj, rid, ctx_filename)
+                        filename = self.get_filename(
+                            obj, rid, ctx_filename, context=context)
                     else:
-                        filename = self.get_filename(obj, rid, name)
+                        filename = self.get_filename(
+                            obj, rid, name, context=context)
 
                 content = base64.b64decode(value)
                 length = len(content)


### PR DESCRIPTION
- Minio Backend: Create filename with subfolder to create folders into bucket
- Minio ir.attachemnts:
    - Using res_model as subfolder when attach files
    - Using `datas_fname` as forced filename in attachments
    - Slugify `datas_fname` ans `filename` except `.` as filename in Minio
    - Add `slugify` as requirements

### subfolder

![imatge](https://user-images.githubusercontent.com/4963636/196009837-e91ca304-0e5c-4a24-99ea-0d3c0df743a9.png)

### Slugify filename
![imatge](https://user-images.githubusercontent.com/4963636/196009919-4e356574-c1db-4e01-8241-416f4a0a321a.png)

![imatge](https://user-images.githubusercontent.com/4963636/196009937-d5665e7f-32aa-49d8-a472-1152a62ca521.png)
