### PR TITLE
Bug Fix: Ensure datas_fname on attachment vals has value on create and write methods

### DIFF
--- a/ir_attachment_minio/ir_attachment.py
+++ b/ir_attachment_minio/ir_attachment.py
@@ -31,7 +31,7 @@ class IrAttachment(osv.osv):
         if context is None:
             context = {}
         ctx = context.copy()
-        if 'datas_fname' in vals:
+        if 'datas_fname' in vals and vals['datas_fname']:
             ctx['datas_minio_filename'] = slugify(
                 vals['datas_fname'], separator='.'
             )
@@ -46,7 +46,7 @@ class IrAttachment(osv.osv):
         ctx = context.copy()
         if 'datas' in vals:
             minioize(vals)
-        if 'datas_fname' in vals:
+        if 'datas_fname' in vals and vals['datas_fname']:
             ctx['datas_minio_filename'] = slugify(
                 vals['datas_fname'], separator='.'
             )


### PR DESCRIPTION
## Sentry Issue

- [x] https://sentry.monitoring.gisce.net/organizations/gisce/issues/32509/?query=is%3Aunresolved+%21level%3Awarning+%21message%3Awarning+assigned%3Anone+error.type%3ATypeError&referrer=issue-stream&statsPeriod=14d&stream_index=2