### PR TITLE
Avoid exception if file does not exist

### DIFF
--- a/.github/workflows/azure_tests.yml
+++ b/.github/workflows/azure_tests.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   run-tests:
     if: github.event_name == 'pull_request' && github.event.label.name == 'to be merged'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/minio_tests.yml
+++ b/.github/workflows/minio_tests.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   run-tests:
     if: github.event_name == 'pull_request' && github.event.label.name == 'to be merged'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/minio_backend/fields.py
+++ b/minio_backend/fields.py
@@ -6,6 +6,7 @@ from io import BytesIO
 from .minio_backend import get_minio_client
 import magic
 from slugify import slugify
+from minio import error
 
 
 class S3File(fields.text):
@@ -88,16 +89,21 @@ class S3File(fields.text):
         res = self.get_oids(cursor, obj, ids, name)
         for rid, oid in res.items():
             if oid:
-                response = client.get_object(self.bucket, oid)
+                response = None
                 try:
+                    response = client.get_object(self.bucket, oid)
                     val = response.data
                     if context.get('bin_size', False) and val:
                         res[rid] = '%s' % human_size(val)
                     else:
                         res[rid] = base64.b64encode(val)
+                except error.NoSuchKey as e:
+                    print("Some one removed de file from minio but not in erp attatchment")
+                    res[rid] = False
                 finally:
-                    response.close()
-                    response.release_conn()
+                    if response is not None:
+                        response.close()
+                        response.release_conn()
             else:
                 res[rid] = False
         return res

--- a/minio_backend/tests/__init__.py
+++ b/minio_backend/tests/__init__.py
@@ -46,6 +46,28 @@ class MiniModelSlug(osv.osv):
 
 
 class TestMinioBackend(testing.OOTestCaseWithCursor):
+    def test_field_get_return_false_if_file_does_not_exist(self):
+        cursor = self.cursor
+        uid = self.uid
+        MiniModel()
+        osv.class_pool['minio.model'].createInstance(
+            self.openerp.pool, 'minio_backend', cursor
+        )
+        obj = self.openerp.pool.get('minio.model')
+        obj._auto_init(cursor)
+
+        content = b'TEST'
+
+        obj_id = obj.create(cursor, uid, {
+            'name': 'Foo',
+            'file': base64.b64encode(content)
+        })
+        path = 'minio_model/{}_file'.format(obj_id)
+        client = get_minio_client()
+        client.remove_object('test', path)
+        result = obj.read(cursor, uid, obj_id, ['file'])
+        self.assertEqual(result['file'], False)
+        self.assertEqual(obj._columns['file'].get(cursor, obj, [obj_id], 'minio_model'), {obj_id: False})
 
     def test_raises_exception_if_not_configured(self):
         from minio_backend.minio_backend import get_minio_client


### PR DESCRIPTION
If a file does not exist in MinIO, return False as value on S3File.get instead of raising a NoSuchKey error.